### PR TITLE
Temporarily comment out math md plugins

### DIFF
--- a/lib/serialize.ts
+++ b/lib/serialize.ts
@@ -11,8 +11,8 @@ export const serialize:any = async (content: any, data: any) => {
   return await mdxSerialize(content, {
     scope: data,
     mdxOptions: {
-      remarkPlugins: [remarkGfm, /*remarkBreaks,*/ remarkMath],
-      rehypePlugins: [rehypeSlug, rehypeMathjax],
+      remarkPlugins: [remarkGfm, /*remarkBreaks, remarkMath*/],
+      rehypePlugins: [rehypeSlug, /*rehypeMathjax*/],
     },
   });
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,8 +16,8 @@ const nextConfig = {
 const withMDX = createMDX({
   extension: /\.mdx?$/,
   options: {
-    remarkPlugins: [remarkGfm, /*remarkBreaks,*/ remarkMath],
-    rehypePlugins: [rehypeSlug, rehypeMathjax],
+    remarkPlugins: [remarkGfm, /*remarkBreaks, remarkMath*/],
+    rehypePlugins: [rehypeSlug, /*rehypeMathjax*/],
     providerImportSource: '@mdx-js/react', // for MDXProvider
   },
 });

--- a/pages/markdown.mdx
+++ b/pages/markdown.mdx
@@ -186,8 +186,6 @@ You can create a nested list by indenting one or more list items below another i
 ![Nested list with alignment highlighted](https://docs.github.com/assets/cb-5185/images/help/writing/nested-list-alignment.png)
 
 ### Task lists
-> **This feature is not yet working on blog posts and state pages. Sorry!**
-
 To create a task list, preface unordered list items and space followed by `[ ]`. To mark a task as complete, use `[x]`.
 
 <u>Example:</u>
@@ -207,8 +205,6 @@ You can create a new paragraph by leaving a blank line between lines of text.
 
 ## Footnotes
 ---
-> **This feature is not yet working on blog posts and state pages. Sorry!**
-
 You can add footnotes to your content by using this bracket syntax:
 
 ```markdown
@@ -266,8 +262,6 @@ Use a triple underscore `___`, dash `---`, or asterisk `***`.
 
 ## Tables
 ---
-> **This feature is not yet working on blog posts and state pages. Sorry!**
-
 You can add tables to your content by using this syntax:
 
 ```markdown


### PR DESCRIPTION
remark-math and/or rehype-mathjax are causing react hydration errors, reason unknown

Mathjax component still works for methodology page